### PR TITLE
Prevent pkill from stopping deployment

### DIFF
--- a/roles/jaspar/tasks/03-user-django.yml
+++ b/roles/jaspar/tasks/03-user-django.yml
@@ -52,7 +52,7 @@
     - jaspar
     - 03-user-django
   ansible.builtin.shell:
-    cmd: 'pkill -f qcluster; nohup python {{ jaspar_app_dir }}/manage.py qcluster & sleep 5'
+    cmd: 'pkill -f qcluster || true; nohup python {{ jaspar_app_dir }}/manage.py qcluster & sleep 5'
     chdir: '{{ jaspar_app_dir }}'
   environment:
     PYTHONPATH: '{{ pythonpath.stdout }}'


### PR DESCRIPTION
Prevent pkill from returning status code 1 if no instance of qcluster exists